### PR TITLE
Edited template link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@ We've written up specifics on [how to run a path analysis](https://github.com/18
 Check out the [previous path analysis projects](https://github.com/18F/path-analysis/blob/master/projects.md).
 
 ## Templates
-- [Path Analysis Report Template](https://docs.google.com/document/d/1DBgwnnHuvR2fAojOwjP8gZ3_jA9pEAGRRKOnmH69d0s/edit?pli=1#heading=h.b6vwy1wu1e2v) (make a copy first!)
+- [Path Analysis Report Template](https://docs.google.com/document/d/1DBgwnnHuvR2fAojOwjP8gZ3_jA9pEAGRRKOnmH69d0s/) (make a copy first!)


### PR DESCRIPTION
The template link was jumping directly to a header, thereby skipping the guidance page at the beginning of the report template. I've removed the anchor link so that this links to the beginning of the template doc.