### PR TITLE
Re-order by agency groupings

### DIFF
--- a/projects.md
+++ b/projects.md
@@ -12,29 +12,31 @@ _Please note: many project deliverables are links to internal documents, and acc
 
 ## Past projects
 
-- [Cabinet-level agencies]()
+- [Cabinet-level agencies](#Cabinet-level-agencies)
+  - [Agriculture (USDA)](#Department-of-Agriculture-USDA)
+  - [Commerce](#Department-of-Commerce-Commerce)
 - [Independent agencies]()
 - [General Services Administration]()
 
 ## Cabinet-level agencies
 
-## Department of Agriculture (USDA)
+### Department of Agriculture (USDA)
 
-### USDA / Food & Nutrition Service (FNS) Supplemental Nutrition Assistance Program (SNAP) Path Analysis [#782](https://tock.18f.gov/projects/782/)
+#### USDA / Food & Nutrition Service (FNS) Supplemental Nutrition Assistance Program (SNAP) Path Analysis [#782](https://tock.18f.gov/projects/782/)
 - June 2018
 - Team: Nikki Zeichner, Roger Ruiz
 - The Food and Nutrition Service within USDA is working on building a workflow and information management system to streamline SNAP key business processes related to State waiver and policy questions processing. Understanding how to best move forward with the workflow information management system will help FNS support State modernization efforts to provide efficient customer service, targeted benefit delivery to those most in need of food assistance, and application of consistent program requirements that reduce improper payments.
 - Deliverables: [final report](https://drive.google.com/drive/u/0/folders/1XyQ-wQompkiZBGm93X_UY7xiRmOG7mL7), [final code evaluation](https://drive.google.com/drive/u/0/folders/1XyQ-wQompkiZBGm93X_UY7xiRmOG7mL7), [project folder](https://drive.google.com/drive/u/0/folders/15z2JFJG2Ygt8AxyAZaIXxFeZrg8JmaCH)
 
-## Department of Commerce (Commerce)
+### Department of Commerce (Commerce)
 
-### Commerce / GEMS Path Analysis [#875](https://tock.18f.gov/projects/875/)
+#### Commerce / GEMS Path Analysis [#875](https://tock.18f.gov/projects/875/)
 - July-August 2018
 - Team: Mike Gintz, Fureigh, Olesya Minina, Mark Hopson
 - Help the Department of Commerce move successfully towards the build or acquisition of a Commerce-wide grants system that will replace their current system, which is not an effective tool for all of their grant-making bureaus and which has technical flaws that would be impractical to fix. In the process, introduce DOC to agile working methods and help them utilize the GEMS project as a catalyst for building an agile culture. 
 - Deliverables: [final report](https://drive.google.com/open?id=1kooL7aORn5-dkhCu7-SS1IdpWYVr8q86ha2NBY9yQQA), [supporting documents](https://drive.google.com/drive/folders/1cGaWUWfoe2Gdr0PIF1tEvU9SDRXGiYw9), [project folder](https://drive.google.com/drive/folders/1mIUXK5Ki3K3_8yevTjpZlzip27OELn0R)
 
-## Department of Defense (DOD)
+### Department of Defense (DOD)
 
 ### Department of Defense Education Activity (DoDEA) Cyber Training Ranges Foundation Engagement [#778](https://tock.18f.gov/projects/778/)
 - May 2018
@@ -42,97 +44,97 @@ _Please note: many project deliverables are links to internal documents, and acc
 - The Cyber Missions Forces have reported difficulty accessing training resources provided by cyber ranges. Timely access to cyber ranges and required training are crucial for ensuring that cyber teams are prepared to respond to increasing cyber threats.
 - Deliverables: [final report](https://docs.google.com/document/d/18SXu6SxUqmOJ07reaavpMI4tnPSNhc1jMu34M9SLuTI/edit?ts=5afb3077#), [project folder](https://drive.google.com/drive/u/0/folders/1LMnwXL3voTPsTlGLOX4VJxrV1QN-S4Ht)
 
-### Defense Travel Management Office (DTMO) Path Analysis [#915](https://tock.18f.gov/projects/915/)
+#### Defense Travel Management Office (DTMO) Path Analysis [#915](https://tock.18f.gov/projects/915/)
 - August-September 2018
 - Team: Eddie Tejeda, Cordelia Yu, Kathryn Connolly
 - The Defense Travel Management Office (DTMO) provides travel support and information to Department of Defense (DoD) Service members and civilian staff. We helped develop a strategy for their main website based on key user needs. 
 - Deliverables: [final report](https://docs.google.com/document/d/1AmdPUki2t33t5PZjLZQ4do-YOUloEISAFjQfqOY2tGg/edit#), [project folder](https://drive.google.com/drive/folders/1-BeA3L0JpS45uOVeA673UddOBlXGMznh)
 
-### U.S. Air Force Recruiting Services Path Analysis [#784](https://tock.18f.gov/projects/784/)
+#### U.S. Air Force Recruiting Services Path Analysis [#784](https://tock.18f.gov/projects/784/)
 - June 2018
 - Team: Andrew Suprenant, James Hupp
 - Assess the current state of the Air Force Recruiting Information Support System-Total Force (AFRISS-TF) and develop a high-level vision for a more modular and mobile-friendly system.
 - Deliverables: [final report](https://docs.google.com/document/d/1W7sAvftbq7mKltg_et_hfEDpZSAs74kwqyzS4-INrzI/edit), [final presentation](https://docs.google.com/presentation/d/11EGm1abVPiR2HAYAu7FHmMw6_ya20bq-FWDepQTBBaQ/edit), [project folder](https://drive.google.com/drive/u/0/folders/15_hzcako6YoYnSl_0apZHuLhLVpLTLkS)
 
-### U.S. Marine Corps (USMC) - Logistics and Planning PAs [#940](https://tock.18f.gov/projects/940/)
+#### U.S. Marine Corps (USMC) - Logistics and Planning PAs [#940](https://tock.18f.gov/projects/940/)
 - underway
 - Team: Michael Antiporta, Mark Headd, Brandon Kirby, Sarah Eckert, Rad Vrajmohan, Stephanie Rivera
 - The Marine Corps Deputy Commandant for Installations and Logistics (DC I&L) is looking to improve its logistics operations, plans, policies, concepts, exercising staff supervision over joint and Marine Corps logistics matters, logistics manpower matters, logistics analysis, mobility, lift requirements, sustainability productivity, material readiness, logistics information systems, security assistance, fiscal matters for appropriate division sponsored programs, and coordinating the logistics aspects of prepositioning programs.
 - Deliverables: [final report], [project folder](https://drive.google.com/drive/folders/1q3fxPn2rbe0v2-uhzfxfnVgbIySOqiGB)
 
-### U.S. Navy Naval Air Systems Command (NAVAIR) Path Analysis [#903](https://tock.18f.gov/projects/903/)
+#### U.S. Navy Naval Air Systems Command (NAVAIR) Path Analysis [#903](https://tock.18f.gov/projects/903/)
 - July-September 2018
 - Team: Andrew Suprenant, TC Baxter, Kathryn Connolly
 - Improve the quality of the data NAVAIR HR collects and manages through better data modeling to inform the use of predictive analytics, allowing the command to better identify past trends and better plan for the future, ultimately strengthening hiring and retention forecasting to better serve Navy and Marine fleets.
 - Deliverables: [final report](https://docs.google.com/document/d/1UGNp-ue8GsFXwZ5VGjNiIkUtvtxttoAi9UdXjKtDOo4/edit#), [final presentation](https://docs.google.com/presentation/d/1MO_lrPBIa0mYc8dfQJrpXy_IYNTRf1RTAAIy3M8YzSY/edit), [project folder](https://drive.google.com/drive/u/0/folders/1Zi8TiYQBV21oXyCYRQf2eXoKE0mXHEqQ)
 
-## Department of Homeland Security (DHS)
+### Department of Homeland Security (DHS)
 
-### DHS / TSA U.S. Air Marshals Foundation Engagement [#597](https://tock.18f.gov/projects/597/)
+#### DHS / TSA U.S. Air Marshals Foundation Engagement [#597](https://tock.18f.gov/projects/597/)
 - October 2017
 - Team: Melissa Braxton, Jacob Harris
 - Analyze the current state of the Mission Scheduler Notification System and create a strategy and roadmap around how TSA should move forward.
 - Deliverables: [final report](https://docs.google.com/document/d/1dhQJZHwXlEe6IRly_jgkx2__HHiMLBwZiAsyd8wuN6Y/edit?ts=59dee222#heading%3Dh.htsst8wozsne), [project folder](https://drive.google.com/drive/u/0/folders/0B5C7q7Z6FNh9MjItRFE5RnhUWWM)
 
-### DHS / Federal Protective Service (FPS) Financial Revenue System Foundation Engagement [#590](https://tock.18f.gov/projects/590/)
+#### DHS / Federal Protective Service (FPS) Financial Revenue System Foundation Engagement [#590](https://tock.18f.gov/projects/590/)
 - September 2017
 - Team: Brandon Kirby, Jon Carmack
 - Identify a strategic roadmap that will clarify and align the revenue management systems’ various user and stakeholder needs.
 - Deliverables: [final report](https://docs.google.com/document/d/1oT8K8lHb786GuWEix8G_7CrqUWTxnJM12XgLtUajaE8/edit), [project folder](https://drive.google.com/drive/u/0/folders/0B7HrEbLy1aMQbjA2OEtfM0trYWM)
 
-## DHS / FEMA Foundation Engagement [#578](https://tock.18f.gov/projects/578/)
+#### DHS / FEMA Foundation Engagement [#578](https://tock.18f.gov/projects/578/)
 - August 2017
 - Team: Michael Cata, Laura Ponce
 - Conduct user research and assess their workload forecasting challenges; make the Workforce Analysis Tool more user friendly.
 - Deliverables: [final report](https://docs.google.com/presentation/d/1mQOFi1P3MzTzIYOJ4iyBjNi-H0OWdi_AkbJs9qMxLXc/edit#slide=id.g24b041f5be_0_233), [project folder](https://drive.google.com/drive/u/0/folders/0B1iVxB_cv5hZR0FkMHRKY1QzVFk)
 
-## Department of the Interior (DOI)
+### Department of the Interior (DOI)
 
-### Fish and Wildlife Service (FWS) / Harvest Surveys Foundation Engagement [#587](https://tock.18f.gov/projects/587/)
+#### Fish and Wildlife Service (FWS) / Harvest Surveys Foundation Engagement [#587](https://tock.18f.gov/projects/587/)
 - September 2017
 - Team: Alex Pandel, Ric Miller
 - The paper surveys of the annual activities of licensed migratory bird hunters are inefficient, tedious and often contain errors. FWS wants to automate this process to make it easier for their staff to collect information, enable hunters to report better data and decrease errors.
 - Deliverables: [readme](https://docs.google.com/document/d/195j01IFUkzQ34d3HAiD-VdnA1Fn_rrqR2VtUVLZ_4rM/edit), [final report](https://docs.google.com/document/d/1wfJn0Svbn189D4wmBquYt35alqi1awlNni0wHrhoZFk/edit#), [project folder](https://drive.google.com/drive/u/0/folders/0B66nw3kJR0r8TTJtSTVKcTRTNm8)
 
-### DOI / Office of Natural Resources Revenue Data Services Foundation Engagement [#564](https://tock.18f.gov/projects/564/)
+#### DOI / Office of Natural Resources Revenue Data Services Foundation Engagement [#564](https://tock.18f.gov/projects/564/)
 - July 2017
 - Team: Corey Mahoney, Jeremy Canfield
 - Prepare DOI for full ownership of the Natural Resource Revenue Data website by providing documentation, knowledge transfer, infrastructure transfer, transformative activities, and ongoing support and feature development via pairing in order to help facilitate the ownership transition.
 - Deliverables: [final report](https://docs.google.com/presentation/d/1t-c80p7jnvf74srNqbEi00gJ7UbkKsjLJU7DuIvsFwU/edit#slide=id.g1f9751b7dd_0_203), [project folder](https://drive.google.com/drive/u/0/folders/0B_FgIWl2WPMEMDF5ZzN5UWE3aUk)
 
-## Department of Justice (DOJ)
+### Department of Justice (DOJ)
 
-### DOJ / Digital Transformation FY17 [#474](https://tock.18f.gov/projects/474/)
+#### DOJ / Digital Transformation FY17 [#474](https://tock.18f.gov/projects/474/)
 - December 2017
 - Team: Nikki Zeichner, Ed Mullen
 - Investigate creating the Data Ingest and Analytics Resource Center (DIARC) to integrate policies, processes, services, and technology into a shared service that is accessible to all litigation components.
 - Deliverables: [readme](https://docs.google.com/document/d/14A4sr626EKFpdObQkn3vfxBOPmSrKu9EnTKoaaLasW0/edit), [final report](https://docs.google.com/document/d/1-8nze2Vu-LiI_tgKZE_YyU98w75yo7zqRO_zT0_LsEc/edit), [project folder](https://drive.google.com/drive/folders/0B2MQdLyPsR4JM18yOXNWRjNaUGs)
 
-## Social Security Administration (SSA)
+### Social Security Administration (SSA)
 
-### SSA / Disability Case Processing System (DCPS2) Path Analysis [#901](https://tock.18f.gov/projects/901/)
+#### SSA / Disability Case Processing System (DCPS2) Path Analysis [#901](https://tock.18f.gov/projects/901/)
 - date: August 2018
 - Team: David Corwin, Eleni Gesch-Karamanlidis
 - Summary: SSA is seeking to identify the best technical solution for centralizing disability case processing. Determining how an internal disability case processing system (DCPS2) currently stacks up against commercially available alternatives, will help SSA determine whether to continue building or buy.
 - Deliverables: [final report](https://docs.google.com/document/d/1iqXwOsYDSC5BOvpHt_xVyqzIZK3QsNq6yskfJw45lCU/edit), [project folder](https://drive.google.com/drive/u/0/folders/1ln7PFz4hhzPbzQRnSbXcn7MS_mEenZQS?ogsrc=32)
 
-## Department of State (State)
+### Department of State (State)
 
-### State Operations Center Path Analysis [#798](https://tock.18f.gov/projects/798/)
+#### State Operations Center Path Analysis [#798](https://tock.18f.gov/projects/798/)
 - June 2018
 - Team: Brandon Kirby, Kara Reinsel
 - Complete a current state analysis of elements of the Operations Center’s work and create a strategy and roadmap for how the State Department could move forward to modernize Operations Center processes and technology specifically related to knowledge management and information dissemination, and a high-level strategy for future state interoperability across all Operations Center systems.
 - Deliverables: [final report](https://docs.google.com/document/d/1oHZA5gBfY1l7skHCIkfvAyQK1MCbCH6wCCk7w4RmiH8/edit), [project folder](https://drive.google.com/drive/folders/1LkQE0mlQnXHXq3pvgn_k-CffFhd3X8DK)
 
-### State Department / Diamond Tracking Foundation Engagement [#748](https://tock.18f.gov/projects/748/)
+#### State Department / Diamond Tracking Foundation Engagement [#748](https://tock.18f.gov/projects/748/)
 - March 2018
 - Team: Porta Antiporta, Vraj Mohan
 - Assess the problem space around the current website, database and data needs
 - Deliverables: [final report](https://docs.google.com/document/d/1svjmi0nURpRLyRr2O59fOo5zqVpIi4n4b5EdgAXhv-E/edit#heading=h.e8nss3dsefeh), [project folder](https://drive.google.com/drive/u/0/folders/1k5-ySsRUI0LynYif_bxfUvqJfuai4lMb)
 
-## Veterans Affairs (VA)
+### Veterans Affairs (VA)
 
-### VA / Inquiry Routing and Information System (IRIS) Foundation Engagement [#527](https://tock.18f.gov/projects/527/)
+#### VA / Inquiry Routing and Information System (IRIS) Foundation Engagement [#527](https://tock.18f.gov/projects/527/)
 - May 2017
 - Team: Jeremy Canfield, Mark Trammell, Robert Sosinski
 - Take a comprehensive inventory of VA’s Inquiry Routing and Information System (IRIS) alongside the many other systems
@@ -140,6 +142,68 @@ Veterans use and VA representatives work with. Build a roadmap for integrating I
 - Deliverables: [final report](https://drive.google.com/drive/u/0/folders/0B1bszTx6T0szUEdZNHlUNC1waDQ), [project folder](https://drive.google.com/drive/u/0/folders/0B8uvRFgNv6TAbGtJMFUya3Nma2s)
 
 ## Independent agencies
+
+### General Services Administration (GSA)
+
+#### OCIO / GAMS Foundation Engagement [#588](https://tock.18f.gov/projects/588/)
+- September 2017
+- Team: Nikki Zeichner, Amos Stone
+- Examine GAMS as a test bed for researching the current access management systems in place; research various modern authentication methods currently used in the commercial sector.
+- Deliverables: [final report](https://docs.google.com/document/d/1pP0LNUzoi_ZESMW2HRR-si0pzVn8kPDduIWI1wxUj1o/edit#heading=h.n9x70772ub7u), [project folder](https://drive.google.com/drive/u/0/folders/0B6M8a_9TXx6HcjZqdDVERk5xeFk)
+
+#### Federal Acquisition Service (FAS) / Commercial Platforms Foundation Engagement [#758](https://tock.18f.gov/projects/758/)
+- April 2018
+- Team: Michael Cata, Brandon Kirby
+- Define a high-level vision and roadmap for improving the federal purchasing experience.
+- Deliverables: [final report](https://docs.google.com/document/d/1ganft6g1jvChCiqCEABT4ZRX8523IvkDc6N4-YFKuN4/edit#heading=h.nfi7i0o0xz2c), [final presentation](https://docs.google.com/presentation/d/1VtPsmFP0f_FakW-ePs1PanlE0V-npSqMRE2zsjYUhoU/edit#slide=id.g35e4b9e59b_0_203), [project folder](https://drive.google.com/drive/u/0/folders/1St7ki-y6kEU9QvsbV75VgtRsstG0XXZU)
+
+#### Federal Acquisition Service (FAS) / Integrated Awards Environment (IAE) Migration Foundation Engagement [#762](https://tock.18f.gov/projects/762/)
+- April 2018
+- Team: Porta Antiporta, Jon Carmack
+- Analyze the current state of IAE’s systems, review past documentation, and create a strategy and roadmap around how OSM should move forward with the migration of IAE’s system into a new environment.
+- Deliverables: [final report](https://docs.google.com/document/d/1QPmBna_RAyINxJGvmB8tWzCVX0mxBHQfEWEaA3hUxYA/edit), [final presentation](https://docs.google.com/presentation/d/1R8CuF6mGUoorgM25vOZQCUywjV9050DlTdvbwmVRtRA/edit#slide=id.p), [project folder](https://drive.google.com/drive/u/0/folders/1GkffL55wW4uTFXTB6Gf0W0MTV45Vy0j5)
+
+#### Federal Acquisition Service (FAS) / SWID Tag Repository Discovery [#562](https://tock.18f.gov/projects/562/)
+- September 2017
+- Team: Nikki Zeichner, Melissa Braxton
+- Investigate the best way to build or acquire a repository for tracking government software licenses and their identification tags.
+- Deliverables: [final report](https://docs.google.com/document/d/12mefUAsK5PZ0BvKIqrY3hDhym6xeKrRqMd2dgxA7T90/edit#heading=h.3tid87unl71h), [presentation](https://docs.google.com/presentation/d/1llthw2my1PgOQNguwwQvSLiazabnF1yvbecpa5c6RH0/edit#slide=id.g1f6a537e68_0_455), [project folder](https://drive.google.com/drive/u/0/folders/0B6M8a_9TXx6HODNsckdDYkJRYWM)
+
+#### Federal Acquisition Service (FAS) ITC / Memo Compliance & Value Application Foundation Engagement [#517](https://tock.18f.gov/projects/517/)
+- April 2017
+- Team: Cyd Harrell, Michael Cata 
+- How can GSA help client agencies painlessly integrate IT guidance from OMB, and would this compliance guidance act as a compelling value-add service for GSA customers? While OMB guidance is confusing, this wasn't a burning user need. What they and their COs really wish is that GSA would make it easier to find vendors who can meet their specific requirements.
+- Deliverables: [final report](https://docs.google.com/document/d/1kigDq4JX_JVbAHaxaeDH-YtsgmbdRrvdB5fOtGeSfxk/edit), [project folder](https://drive.google.com/drive/u/0/folders/0B1iVxB_cv5hZTG9UNGVaTENEQVE)
+
+#### Office of Products and Programs (OPP) / Social Security Number (SSN) Foundation Engagement [#493](https://tock.18f.gov/projects/493/)
+- January 2017
+- Team: Cyd Harrell, Ric Miller 
+- Assess the current environment of privacy-protecting citizen identifiers and demo the existing proof of concept of the Program Unique Identifier Initiative developed by OPM. Stopped the project after three weeks because there was no existing proof of concept and the partner wasn't ready to work with us.
+- Deliverables: [final report](https://docs.google.com/document/d/1Cts4OmwY8kEIMvgWF3bhR4hTBZgwczufptKEBz450D4/edit), [project folder](https://drive.google.com/drive/u/0/folders/0B15x0N-o0ueNTENxTlBPYllWcGc)
+
+#### Office of Products and Programs / Performance.gov Foundation Engagement [#663](https://tock.18f.gov/projects/663/)
+- November 2017
+- Team: Victor Udoewa, Eddie Tejeda
+- Assess the archived Performance.gov and create a product vision and roadmap for a new, modernized Performance.gov
+- Deliverables: [readme](https://docs.google.com/document/d/18FBZ0yDos77KLRLOTVUU3hCA_oFczxJlHSIKgl3gwNY/edit?ts=5a99b58f), [final report](https://docs.google.com/presentation/d/1TFh3r3Cdd_wiCuli1rpY4RkkMXfYXIfXCS2fv7B5o7o/edit), [project folder](https://drive.google.com/drive/u/0/folders/0Bykd9KmMpACXRUl2RDdGZjNucFk)
+
+#### Office of Products and Programs / Agency-wide Content Delivery Foundation Engagement [#647](https://tock.18f.gov/projects/647/)
+- October 2017
+- Team: Tim Jones, Andrew Maier
+- Assist OPP with market and user research, roadmap a vision for which roles TTS could effectively take on to help agencies with their content delivery needs.
+- Deliverables: [final report](https://docs.google.com/document/d/1v0IaGPTh981ZsBYOTCdo2CVy0IxJnzWO7-3HS2RMGDI/edit#), [project folder](https://drive.google.com/drive/u/0/folders/0B_SvrGV09nQ-V2NxSFhjUGs5LWs)
+
+#### Office of Products and Programs (OPP) / USA.gov Consolidated Permit System Foundation Engagement [#536](https://tock.18f.gov/projects/536/)
+- June 2017
+- Team: Michael Cata, Nick Brethauer
+- Learn more about the problem landscape as well as assess the viability of building a service to improve the user experience of land-use permit requests.
+- Deliverables: [final report](https://docs.google.com/presentation/d/1xwZmmCDvOKzzMEnaglql99NhwQEnp34vRNRIIUz0Lhc/edit#slide=id.g1f55217fec_0_372), [project folder](https://drive.google.com/drive/u/0/folders/0B_n2YScccqDXemRHOVZtcU9FdFU), [project repo](https://github.com/18F/FFD_landuse)
+
+#### Office of Products and Programs (OPP) / Small Business Grant Foundation Engagement [#528](https://tock.18f.gov/projects/528/)
+- May 2017
+- Team: Ric Miller, Carolyn Dew
+- After inheriting BusinessUSA, USAGov wanted to identify opportunities to improve how small businesses interact with the federal government. We set out to better understand how small businesses interact with the federal government, directly or indirectly. We focused on federal grant dollars that are awarded to state or local entities, and which are then issued as contracts with specific small or disadvantaged business requirements.
+- Deliverables: [final report](https://github.com/18F/OPP-BusinessUSA-research/blob/master/small-business-discovery-handout.md), [project repo](https://github.com/18F/OPP-BusinessUSA-research)
 
 ### National Science Foundation (NSF) / Site Redesign Foundation Engagement [#515](https://tock.18f.gov/projects/515/)
 - May 2017
@@ -158,65 +222,3 @@ Veterans use and VA representatives work with. Build a roadmap for integrating I
 - Team: Victor Udoewa, Andrew Maier
 - Conduct user research in order to identify a potential roadmap for user-centered improvements to PubMed.gov and NLM literature offerings in general.
 - Deliverables: [readme](https://docs.google.com/document/d/1W2-SbeepLxEv9LfXjFelDg8u_6CxkMIY7wZZTDDh-wc/edit?ts=5a99b796), [final report](https://docs.google.com/presentation/d/1d7Rjme9tv5sQi9PMDPMv7Cmww4T-R3IuuUMmNm4iGfM/edit#slide=id.g35d13d9c9a_0_1349), [project folder](https://drive.google.com/drive/u/0/folders/1jPGVD44o3LoHlWI1KabzLBJe4SbhafNN)
-
-## General Services Administration (GSA)
-
-### OCIO / GAMS Foundation Engagement [#588](https://tock.18f.gov/projects/588/)
-- September 2017
-- Team: Nikki Zeichner, Amos Stone
-- Examine GAMS as a test bed for researching the current access management systems in place; research various modern authentication methods currently used in the commercial sector.
-- Deliverables: [final report](https://docs.google.com/document/d/1pP0LNUzoi_ZESMW2HRR-si0pzVn8kPDduIWI1wxUj1o/edit#heading=h.n9x70772ub7u), [project folder](https://drive.google.com/drive/u/0/folders/0B6M8a_9TXx6HcjZqdDVERk5xeFk)
-
-### Federal Acquisition Service (FAS) / Commercial Platforms Foundation Engagement [#758](https://tock.18f.gov/projects/758/)
-- April 2018
-- Team: Michael Cata, Brandon Kirby
-- Define a high-level vision and roadmap for improving the federal purchasing experience.
-- Deliverables: [final report](https://docs.google.com/document/d/1ganft6g1jvChCiqCEABT4ZRX8523IvkDc6N4-YFKuN4/edit#heading=h.nfi7i0o0xz2c), [final presentation](https://docs.google.com/presentation/d/1VtPsmFP0f_FakW-ePs1PanlE0V-npSqMRE2zsjYUhoU/edit#slide=id.g35e4b9e59b_0_203), [project folder](https://drive.google.com/drive/u/0/folders/1St7ki-y6kEU9QvsbV75VgtRsstG0XXZU)
-
-### Federal Acquisition Service (FAS) / Integrated Awards Environment (IAE) Migration Foundation Engagement [#762](https://tock.18f.gov/projects/762/)
-- April 2018
-- Team: Porta Antiporta, Jon Carmack
-- Analyze the current state of IAE’s systems, review past documentation, and create a strategy and roadmap around how OSM should move forward with the migration of IAE’s system into a new environment.
-- Deliverables: [final report](https://docs.google.com/document/d/1QPmBna_RAyINxJGvmB8tWzCVX0mxBHQfEWEaA3hUxYA/edit), [final presentation](https://docs.google.com/presentation/d/1R8CuF6mGUoorgM25vOZQCUywjV9050DlTdvbwmVRtRA/edit#slide=id.p), [project folder](https://drive.google.com/drive/u/0/folders/1GkffL55wW4uTFXTB6Gf0W0MTV45Vy0j5)
-
-## Federal Acquisition Service (FAS) / SWID Tag Repository Discovery [#562](https://tock.18f.gov/projects/562/)
-- September 2017
-- Team: Nikki Zeichner, Melissa Braxton
-- Investigate the best way to build or acquire a repository for tracking government software licenses and their identification tags.
-- Deliverables: [final report](https://docs.google.com/document/d/12mefUAsK5PZ0BvKIqrY3hDhym6xeKrRqMd2dgxA7T90/edit#heading=h.3tid87unl71h), [presentation](https://docs.google.com/presentation/d/1llthw2my1PgOQNguwwQvSLiazabnF1yvbecpa5c6RH0/edit#slide=id.g1f6a537e68_0_455), [project folder](https://drive.google.com/drive/u/0/folders/0B6M8a_9TXx6HODNsckdDYkJRYWM)
-
-### Federal Acquisition Service (FAS) ITC / Memo Compliance & Value Application Foundation Engagement [#517](https://tock.18f.gov/projects/517/)
-- April 2017
-- Team: Cyd Harrell, Michael Cata 
-- How can GSA help client agencies painlessly integrate IT guidance from OMB, and would this compliance guidance act as a compelling value-add service for GSA customers? While OMB guidance is confusing, this wasn't a burning user need. What they and their COs really wish is that GSA would make it easier to find vendors who can meet their specific requirements.
-- Deliverables: [final report](https://docs.google.com/document/d/1kigDq4JX_JVbAHaxaeDH-YtsgmbdRrvdB5fOtGeSfxk/edit), [project folder](https://drive.google.com/drive/u/0/folders/0B1iVxB_cv5hZTG9UNGVaTENEQVE)
-
-### Office of Products and Programs (OPP) / Social Security Number (SSN) Foundation Engagement [#493](https://tock.18f.gov/projects/493/)
-- January 2017
-- Team: Cyd Harrell, Ric Miller 
-- Assess the current environment of privacy-protecting citizen identifiers and demo the existing proof of concept of the Program Unique Identifier Initiative developed by OPM. Stopped the project after three weeks because there was no existing proof of concept and the partner wasn't ready to work with us.
-- Deliverables: [final report](https://docs.google.com/document/d/1Cts4OmwY8kEIMvgWF3bhR4hTBZgwczufptKEBz450D4/edit), [project folder](https://drive.google.com/drive/u/0/folders/0B15x0N-o0ueNTENxTlBPYllWcGc)
-
-### Office of Products and Programs / Performance.gov Foundation Engagement [#663](https://tock.18f.gov/projects/663/)
-- November 2017
-- Team: Victor Udoewa, Eddie Tejeda
-- Assess the archived Performance.gov and create a product vision and roadmap for a new, modernized Performance.gov
-- Deliverables: [readme](https://docs.google.com/document/d/18FBZ0yDos77KLRLOTVUU3hCA_oFczxJlHSIKgl3gwNY/edit?ts=5a99b58f), [final report](https://docs.google.com/presentation/d/1TFh3r3Cdd_wiCuli1rpY4RkkMXfYXIfXCS2fv7B5o7o/edit), [project folder](https://drive.google.com/drive/u/0/folders/0Bykd9KmMpACXRUl2RDdGZjNucFk)
-
-### Office of Products and Programs / Agency-wide Content Delivery Foundation Engagement [#647](https://tock.18f.gov/projects/647/)
-- October 2017
-- Team: Tim Jones, Andrew Maier
-- Assist OPP with market and user research, roadmap a vision for which roles TTS could effectively take on to help agencies with their content delivery needs.
-- Deliverables: [final report](https://docs.google.com/document/d/1v0IaGPTh981ZsBYOTCdo2CVy0IxJnzWO7-3HS2RMGDI/edit#), [project folder](https://drive.google.com/drive/u/0/folders/0B_SvrGV09nQ-V2NxSFhjUGs5LWs)
-
-## Office of Products and Programs (OPP) / USA.gov Consolidated Permit System Foundation Engagement [#536](https://tock.18f.gov/projects/536/)
-- June 2017
-- Team: Michael Cata, Nick Brethauer
-- Learn more about the problem landscape as well as assess the viability of building a service to improve the user experience of land-use permit requests.
-- Deliverables: [final report](https://docs.google.com/presentation/d/1xwZmmCDvOKzzMEnaglql99NhwQEnp34vRNRIIUz0Lhc/edit#slide=id.g1f55217fec_0_372), [project folder](https://drive.google.com/drive/u/0/folders/0B_n2YScccqDXemRHOVZtcU9FdFU), [project repo](https://github.com/18F/FFD_landuse)
-
-## Office of Products and Programs (OPP) / Small Business Grant Foundation Engagement [#528](https://tock.18f.gov/projects/528/)
-- May 2017
-- Team: Ric Miller, Carolyn Dew
-- After inheriting BusinessUSA, USAGov wanted to identify opportunities to improve how small businesses interact with the federal government. We set out to better understand how small businesses interact with the federal government, directly or indirectly. We focused on federal grant dollars that are awarded to state or local entities, and which are then issued as contracts with specific small or disadvantaged business requirements.
-- Deliverables: [final report](https://github.com/18F/OPP-BusinessUSA-research/blob/master/small-business-discovery-handout.md), [project repo](https://github.com/18F/OPP-BusinessUSA-research)

--- a/projects.md
+++ b/projects.md
@@ -2,139 +2,182 @@
 
 _Please note: many project deliverables are links to internal documents, and access may be limited to 18F and partner agency staff._
 
-## Name of project [tock code]
+## Template
+
+### Name of project [tock code]
 - date
 - Team: 
 - summary
 - Deliverables: [final report], [project folder]
 
-## US Marine Corps (USMC] - Logistics and Planning PAs [#940](https://tock.18f.gov/projects/940/)
-- underway
-- Team: Michael Antiporta, Mark Headd, Brandon Kirby, Sarah Eckert, Rad Vrajmohan, Stephanie Rivera
-- The Marine Corps Deputy Commandant for Installations and Logistics (DC I&L) is looking to improve its logistics operations, plans, policies, concepts, exercising staff supervision over joint and Marine Corps logistics matters, logistics manpower matters, logistics analysis, mobility, lift requirements, sustainability productivity, material readiness, logistics information systems, security assistance, fiscal matters for appropriate division sponsored programs, and coordinating the logistics aspects of prepositioning programs.
-- Deliverables: [final report], [project folder](https://drive.google.com/drive/folders/1q3fxPn2rbe0v2-uhzfxfnVgbIySOqiGB)
+## Past projects
 
-## U.S. Navy Naval Air Systems Command (NAVAIR) Path Analysis [#903](https://tock.18f.gov/projects/903/)
-- July-September 2018
-- Team: Andrew Suprenant, TC Baxter, Kathryn Connolly
-- Improve the quality of the data NAVAIR HR collects and manages through better data modeling to inform the use of predictive analytics, allowing the command to better identify past trends and better plan for the future, ultimately strengthening hiring and retention forecasting to better serve Navy and Marine fleets.
-- Deliverables: [final report](https://docs.google.com/document/d/1UGNp-ue8GsFXwZ5VGjNiIkUtvtxttoAi9UdXjKtDOo4/edit#), [final presentation](https://docs.google.com/presentation/d/1MO_lrPBIa0mYc8dfQJrpXy_IYNTRf1RTAAIy3M8YzSY/edit), [project folder](https://drive.google.com/drive/u/0/folders/1Zi8TiYQBV21oXyCYRQf2eXoKE0mXHEqQ)
+- [Cabinet-level agencies]()
+- [Independent agencies]()
+- [General Services Administration]()
 
-## Social Security Administration / Disability Case Processing System (DCPS2) Path Analysis [#901](https://tock.18f.gov/projects/901/)
-- date: August 2018
-- Team: David Corwin, Eleni Gesch-Karamanlidis
-- Summary: SSA is seeking to identify the best technical solution for centralizing disability case processing. Determining how an internal disability case processing system (DCPS2) currently stacks up against commercially available alternatives, will help SSA determine whether to continue building or buy.
+## Cabinet-level agencies
 
-- Deliverables: [final report](https://docs.google.com/document/d/1iqXwOsYDSC5BOvpHt_xVyqzIZK3QsNq6yskfJw45lCU/edit), [project folder](https://drive.google.com/drive/u/0/folders/1ln7PFz4hhzPbzQRnSbXcn7MS_mEenZQS?ogsrc=32)
+## Department of Agriculture (USDA)
 
-## Department of State / Operations Center Path Analysis [#798](https://tock.18f.gov/projects/798/)
-- June 2018
-- Team: Brandon Kirby, Kara Reinsel
-- Complete a current state analysis of elements of the Operations Center’s work and create a strategy and roadmap for how the State Department could move forward to modernize Operations Center processes and technology specifically related to knowledge management and information dissemination, and a high-level strategy for future state interoperability across all Operations Center systems.
-- Deliverables: [final report](https://docs.google.com/document/d/1oHZA5gBfY1l7skHCIkfvAyQK1MCbCH6wCCk7w4RmiH8/edit), [project folder](https://drive.google.com/drive/folders/1LkQE0mlQnXHXq3pvgn_k-CffFhd3X8DK)
-
-## DOC / GEMS Path Analysis [#875](https://tock.18f.gov/projects/875/)
-- July-August 2018
-- Team: Mike Gintz, Fureigh, Olesya Minina, Mark Hopson
-- Help the Department of Commerce move successfully towards the build or acquisition of a Commerce-wide grants system that will replace their current system, which is not an effective tool for all of their grant-making bureaus and which has technical flaws that would be impractical to fix. In the process, introduce DOC to agile working methods and help them utilize the GEMS project as a catalyst for building an agile culture. 
-- Deliverables: [final report](https://drive.google.com/open?id=1kooL7aORn5-dkhCu7-SS1IdpWYVr8q86ha2NBY9yQQA), [supporting documents](https://drive.google.com/drive/folders/1cGaWUWfoe2Gdr0PIF1tEvU9SDRXGiYw9), [project folder](https://drive.google.com/drive/folders/1mIUXK5Ki3K3_8yevTjpZlzip27OELn0R)
-
-## US Department of Agriculture / Food & Nutrition Service (FNS) Supplemental Nutrition Assistance Program (SNAP) Path Analysis [#782](https://tock.18f.gov/projects/782/)
+### USDA / Food & Nutrition Service (FNS) Supplemental Nutrition Assistance Program (SNAP) Path Analysis [#782](https://tock.18f.gov/projects/782/)
 - June 2018
 - Team: Nikki Zeichner, Roger Ruiz
 - The Food and Nutrition Service within USDA is working on building a workflow and information management system to streamline SNAP key business processes related to State waiver and policy questions processing. Understanding how to best move forward with the workflow information management system will help FNS support State modernization efforts to provide efficient customer service, targeted benefit delivery to those most in need of food assistance, and application of consistent program requirements that reduce improper payments.
 - Deliverables: [final report](https://drive.google.com/drive/u/0/folders/1XyQ-wQompkiZBGm93X_UY7xiRmOG7mL7), [final code evaluation](https://drive.google.com/drive/u/0/folders/1XyQ-wQompkiZBGm93X_UY7xiRmOG7mL7), [project folder](https://drive.google.com/drive/u/0/folders/15z2JFJG2Ygt8AxyAZaIXxFeZrg8JmaCH)
 
-## Department of Defense / US Air Force Recruiting Services Path Analysis [#784](https://tock.18f.gov/projects/784/)
-- June 2018
-- Team: Andrew Suprenant, James Hupp
-- Assess the current state of the Air Force Recruiting Information Support System-Total Force (AFRISS-TF) and develop a high-level vision for a more modular and mobile-friendly system.
-- Deliverables: [final report](https://docs.google.com/document/d/1W7sAvftbq7mKltg_et_hfEDpZSAs74kwqyzS4-INrzI/edit), [final presentation](https://docs.google.com/presentation/d/11EGm1abVPiR2HAYAu7FHmMw6_ya20bq-FWDepQTBBaQ/edit), [project folder](https://drive.google.com/drive/u/0/folders/15_hzcako6YoYnSl_0apZHuLhLVpLTLkS)
+## Department of Commerce (Commerce)
 
-## Department of Defense / Education Activity (DoDEA) Cyber Training Ranges Foundation Engagement [#778](https://tock.18f.gov/projects/778/)
+### Commerce / GEMS Path Analysis [#875](https://tock.18f.gov/projects/875/)
+- July-August 2018
+- Team: Mike Gintz, Fureigh, Olesya Minina, Mark Hopson
+- Help the Department of Commerce move successfully towards the build or acquisition of a Commerce-wide grants system that will replace their current system, which is not an effective tool for all of their grant-making bureaus and which has technical flaws that would be impractical to fix. In the process, introduce DOC to agile working methods and help them utilize the GEMS project as a catalyst for building an agile culture. 
+- Deliverables: [final report](https://drive.google.com/open?id=1kooL7aORn5-dkhCu7-SS1IdpWYVr8q86ha2NBY9yQQA), [supporting documents](https://drive.google.com/drive/folders/1cGaWUWfoe2Gdr0PIF1tEvU9SDRXGiYw9), [project folder](https://drive.google.com/drive/folders/1mIUXK5Ki3K3_8yevTjpZlzip27OELn0R)
+
+## Department of Defense (DOD)
+
+### Department of Defense Education Activity (DoDEA) Cyber Training Ranges Foundation Engagement [#778](https://tock.18f.gov/projects/778/)
 - May 2018
 - Team: David Kane-Perry, Eddie Tejeda
 - The Cyber Missions Forces have reported difficulty accessing training resources provided by cyber ranges. Timely access to cyber ranges and required training are crucial for ensuring that cyber teams are prepared to respond to increasing cyber threats.
 - Deliverables: [final report](https://docs.google.com/document/d/18SXu6SxUqmOJ07reaavpMI4tnPSNhc1jMu34M9SLuTI/edit?ts=5afb3077#), [project folder](https://drive.google.com/drive/u/0/folders/1LMnwXL3voTPsTlGLOX4VJxrV1QN-S4Ht)
 
-## Department of Defense / Defense Travel Management Office (DTMO) Path Analysis [#915](https://tock.18f.gov/projects/915/)
+### Defense Travel Management Office (DTMO) Path Analysis [#915](https://tock.18f.gov/projects/915/)
 - August-September 2018
 - Team: Eddie Tejeda, Cordelia Yu, Kathryn Connolly
 - The Defense Travel Management Office (DTMO) provides travel support and information to Department of Defense (DoD) Service members and civilian staff. We helped develop a strategy for their main website based on key user needs. 
 - Deliverables: [final report](https://docs.google.com/document/d/1AmdPUki2t33t5PZjLZQ4do-YOUloEISAFjQfqOY2tGg/edit#), [project folder](https://drive.google.com/drive/folders/1-BeA3L0JpS45uOVeA673UddOBlXGMznh)
 
+### U.S. Air Force Recruiting Services Path Analysis [#784](https://tock.18f.gov/projects/784/)
+- June 2018
+- Team: Andrew Suprenant, James Hupp
+- Assess the current state of the Air Force Recruiting Information Support System-Total Force (AFRISS-TF) and develop a high-level vision for a more modular and mobile-friendly system.
+- Deliverables: [final report](https://docs.google.com/document/d/1W7sAvftbq7mKltg_et_hfEDpZSAs74kwqyzS4-INrzI/edit), [final presentation](https://docs.google.com/presentation/d/11EGm1abVPiR2HAYAu7FHmMw6_ya20bq-FWDepQTBBaQ/edit), [project folder](https://drive.google.com/drive/u/0/folders/15_hzcako6YoYnSl_0apZHuLhLVpLTLkS)
 
-## Federal Acquisition Service (FAS) / Commercial Platforms Foundation Engagement [#758](https://tock.18f.gov/projects/758/)
-- April 2018
-- Team: Michael Cata, Brandon Kirby
-- Define a high-level vision and roadmap for improving the federal purchasing experience.
-- Deliverables: [final report](https://docs.google.com/document/d/1ganft6g1jvChCiqCEABT4ZRX8523IvkDc6N4-YFKuN4/edit#heading=h.nfi7i0o0xz2c), [final presentation](https://docs.google.com/presentation/d/1VtPsmFP0f_FakW-ePs1PanlE0V-npSqMRE2zsjYUhoU/edit#slide=id.g35e4b9e59b_0_203), [project folder](https://drive.google.com/drive/u/0/folders/1St7ki-y6kEU9QvsbV75VgtRsstG0XXZU)
+### U.S. Marine Corps (USMC) - Logistics and Planning PAs [#940](https://tock.18f.gov/projects/940/)
+- underway
+- Team: Michael Antiporta, Mark Headd, Brandon Kirby, Sarah Eckert, Rad Vrajmohan, Stephanie Rivera
+- The Marine Corps Deputy Commandant for Installations and Logistics (DC I&L) is looking to improve its logistics operations, plans, policies, concepts, exercising staff supervision over joint and Marine Corps logistics matters, logistics manpower matters, logistics analysis, mobility, lift requirements, sustainability productivity, material readiness, logistics information systems, security assistance, fiscal matters for appropriate division sponsored programs, and coordinating the logistics aspects of prepositioning programs.
+- Deliverables: [final report], [project folder](https://drive.google.com/drive/folders/1q3fxPn2rbe0v2-uhzfxfnVgbIySOqiGB)
 
-## Federal Acquisition Service (FAS) / Integrated Awards Environment (IAE) Migration Foundation Engagement [#762](https://tock.18f.gov/projects/762/)
-- April 2018
-- Team: Porta Antiporta, Jon Carmack
-- Analyze the current state of IAE’s systems, review past documentation, and create a strategy and roadmap around how OSM should move forward with the migration of IAE’s system into a new environment.
-- Deliverables: [final report](https://docs.google.com/document/d/1QPmBna_RAyINxJGvmB8tWzCVX0mxBHQfEWEaA3hUxYA/edit), [final presentation](https://docs.google.com/presentation/d/1R8CuF6mGUoorgM25vOZQCUywjV9050DlTdvbwmVRtRA/edit#slide=id.p), [project folder](https://drive.google.com/drive/u/0/folders/1GkffL55wW4uTFXTB6Gf0W0MTV45Vy0j5)
+### U.S. Navy Naval Air Systems Command (NAVAIR) Path Analysis [#903](https://tock.18f.gov/projects/903/)
+- July-September 2018
+- Team: Andrew Suprenant, TC Baxter, Kathryn Connolly
+- Improve the quality of the data NAVAIR HR collects and manages through better data modeling to inform the use of predictive analytics, allowing the command to better identify past trends and better plan for the future, ultimately strengthening hiring and retention forecasting to better serve Navy and Marine fleets.
+- Deliverables: [final report](https://docs.google.com/document/d/1UGNp-ue8GsFXwZ5VGjNiIkUtvtxttoAi9UdXjKtDOo4/edit#), [final presentation](https://docs.google.com/presentation/d/1MO_lrPBIa0mYc8dfQJrpXy_IYNTRf1RTAAIy3M8YzSY/edit), [project folder](https://drive.google.com/drive/u/0/folders/1Zi8TiYQBV21oXyCYRQf2eXoKE0mXHEqQ)
 
-## State Department / Diamond Tracking Foundation Engagement [#748](https://tock.18f.gov/projects/748/)
-- March 2018
-- Team: Porta Antiporta, Vraj Mohan
-- Assess the problem space around the current website, database and data needs
-- Deliverables: [final report](https://docs.google.com/document/d/1svjmi0nURpRLyRr2O59fOo5zqVpIi4n4b5EdgAXhv-E/edit#heading=h.e8nss3dsefeh), [project folder](https://drive.google.com/drive/u/0/folders/1k5-ySsRUI0LynYif_bxfUvqJfuai4lMb)
+## Department of Homeland Security (DHS)
 
-## National Institutes of Health (NIH) / PubMed Foundation Engagement [#754](https://tock.18f.gov/projects/754/)
-- March 2018
-- Team: Victor Udoewa, Andrew Maier
-- Conduct user research in order to identify a potential roadmap for user-centered improvements to PubMed.gov and NLM literature offerings in general.
-- Deliverables: [readme](https://docs.google.com/document/d/1W2-SbeepLxEv9LfXjFelDg8u_6CxkMIY7wZZTDDh-wc/edit?ts=5a99b796), [final report](https://docs.google.com/presentation/d/1d7Rjme9tv5sQi9PMDPMv7Cmww4T-R3IuuUMmNm4iGfM/edit#slide=id.g35d13d9c9a_0_1349), [project folder](https://drive.google.com/drive/u/0/folders/1jPGVD44o3LoHlWI1KabzLBJe4SbhafNN)
-
-## Department of Justice / Digital Transformation FY17 [#474](https://tock.18f.gov/projects/474/)
-- December 2017
-- Team: Nikki Zeichner, Ed Mullen
-- Investigate creating the Data Ingest and Analytics Resource Center (DIARC) to integrate policies, processes, services, and technology into a shared service that is accessible to all litigation components.
-- Deliverables: [readme](https://docs.google.com/document/d/14A4sr626EKFpdObQkn3vfxBOPmSrKu9EnTKoaaLasW0/edit), [final report](https://docs.google.com/document/d/1-8nze2Vu-LiI_tgKZE_YyU98w75yo7zqRO_zT0_LsEc/edit), [project folder](https://drive.google.com/drive/folders/0B2MQdLyPsR4JM18yOXNWRjNaUGs)
-
-## Department of the Interior / Office of Natural Resources Revenue Data Services Foundation Engagement [#564](https://tock.18f.gov/projects/564/)
-- December 2017
-- Team: Corey Mahoney, Jeremy Canfield
-- Prepare DOI for full ownership of the USEITI website by providing documentation, knowledge transfer, infrastructure transfer, transformative activities, and ongoing support and feature development via pairing in order to help facilitate the ownership transition.
-- Deliverables: [final report](https://docs.google.com/presentation/d/1t-c80p7jnvf74srNqbEi00gJ7UbkKsjLJU7DuIvsFwU/edit#slide=id.g1f9751b7dd_0_203), [project folder](https://drive.google.com/drive/u/0/folders/0B_FgIWl2WPMEMDF5ZzN5UWE3aUk)
-
-## Office of Products and Programs / Performance.gov Foundation Engagement [#663](https://tock.18f.gov/projects/663/)
-- November 2017
-- Team: Victor Udoewa, Eddie Tejeda
-- Assess the archived Performance.gov and create a product vision and roadmap for a new, modernized Performance.gov
-- Deliverables: [readme](https://docs.google.com/document/d/18FBZ0yDos77KLRLOTVUU3hCA_oFczxJlHSIKgl3gwNY/edit?ts=5a99b58f), [final report](https://docs.google.com/presentation/d/1TFh3r3Cdd_wiCuli1rpY4RkkMXfYXIfXCS2fv7B5o7o/edit), [project folder](https://drive.google.com/drive/u/0/folders/0Bykd9KmMpACXRUl2RDdGZjNucFk)
-
-## Office of Products and Programs / Agency-wide Content Delivery Foundation Engagement [#647](https://tock.18f.gov/projects/647/)
-- October 2017
-- Team: Tim Jones, Andrew Maier
-- Assist OPP with market and user research, roadmap a vision for which roles TTS could effectively take on to help agencies with their content delivery needs.
-- Deliverables: [final report](https://docs.google.com/document/d/1v0IaGPTh981ZsBYOTCdo2CVy0IxJnzWO7-3HS2RMGDI/edit#), [project folder](https://drive.google.com/drive/u/0/folders/0B_SvrGV09nQ-V2NxSFhjUGs5LWs)
-
-## Department of Homeland Security (DHS) / TSA U.S. Air Marshals Foundation Engagement [#597](https://tock.18f.gov/projects/597/)
+### DHS / TSA U.S. Air Marshals Foundation Engagement [#597](https://tock.18f.gov/projects/597/)
 - October 2017
 - Team: Melissa Braxton, Jacob Harris
 - Analyze the current state of the Mission Scheduler Notification System and create a strategy and roadmap around how TSA should move forward.
 - Deliverables: [final report](https://docs.google.com/document/d/1dhQJZHwXlEe6IRly_jgkx2__HHiMLBwZiAsyd8wuN6Y/edit?ts=59dee222#heading%3Dh.htsst8wozsne), [project folder](https://drive.google.com/drive/u/0/folders/0B5C7q7Z6FNh9MjItRFE5RnhUWWM)
 
-## Department of Homeland Security (DHS) / Federal Protective Service (FPS) Financial Revenue System Foundation Engagement [#590](https://tock.18f.gov/projects/590/)
+### DHS / Federal Protective Service (FPS) Financial Revenue System Foundation Engagement [#590](https://tock.18f.gov/projects/590/)
 - September 2017
 - Team: Brandon Kirby, Jon Carmack
 - Identify a strategic roadmap that will clarify and align the revenue management systems’ various user and stakeholder needs.
 - Deliverables: [final report](https://docs.google.com/document/d/1oT8K8lHb786GuWEix8G_7CrqUWTxnJM12XgLtUajaE8/edit), [project folder](https://drive.google.com/drive/u/0/folders/0B7HrEbLy1aMQbjA2OEtfM0trYWM)
 
-## OCIO / GAMS Foundation Engagement [#588](https://tock.18f.gov/projects/588/)
+## DHS / FEMA Foundation Engagement [#578](https://tock.18f.gov/projects/578/)
+- August 2017
+- Team: Michael Cata, Laura Ponce
+- Conduct user research and assess their workload forecasting challenges; make the Workforce Analysis Tool more user friendly.
+- Deliverables: [final report](https://docs.google.com/presentation/d/1mQOFi1P3MzTzIYOJ4iyBjNi-H0OWdi_AkbJs9qMxLXc/edit#slide=id.g24b041f5be_0_233), [project folder](https://drive.google.com/drive/u/0/folders/0B1iVxB_cv5hZR0FkMHRKY1QzVFk)
+
+## Department of the Interior (DOI)
+
+### Fish and Wildlife Service (FWS) / Harvest Surveys Foundation Engagement [#587](https://tock.18f.gov/projects/587/)
+- September 2017
+- Team: Alex Pandel, Ric Miller
+- The paper surveys of the annual activities of licensed migratory bird hunters are inefficient, tedious and often contain errors. FWS wants to automate this process to make it easier for their staff to collect information, enable hunters to report better data and decrease errors.
+- Deliverables: [readme](https://docs.google.com/document/d/195j01IFUkzQ34d3HAiD-VdnA1Fn_rrqR2VtUVLZ_4rM/edit), [final report](https://docs.google.com/document/d/1wfJn0Svbn189D4wmBquYt35alqi1awlNni0wHrhoZFk/edit#), [project folder](https://drive.google.com/drive/u/0/folders/0B66nw3kJR0r8TTJtSTVKcTRTNm8)
+
+### DOI / Office of Natural Resources Revenue Data Services Foundation Engagement [#564](https://tock.18f.gov/projects/564/)
+- July 2017
+- Team: Corey Mahoney, Jeremy Canfield
+- Prepare DOI for full ownership of the Natural Resource Revenue Data website by providing documentation, knowledge transfer, infrastructure transfer, transformative activities, and ongoing support and feature development via pairing in order to help facilitate the ownership transition.
+- Deliverables: [final report](https://docs.google.com/presentation/d/1t-c80p7jnvf74srNqbEi00gJ7UbkKsjLJU7DuIvsFwU/edit#slide=id.g1f9751b7dd_0_203), [project folder](https://drive.google.com/drive/u/0/folders/0B_FgIWl2WPMEMDF5ZzN5UWE3aUk)
+
+## Department of Justice (DOJ)
+
+### DOJ / Digital Transformation FY17 [#474](https://tock.18f.gov/projects/474/)
+- December 2017
+- Team: Nikki Zeichner, Ed Mullen
+- Investigate creating the Data Ingest and Analytics Resource Center (DIARC) to integrate policies, processes, services, and technology into a shared service that is accessible to all litigation components.
+- Deliverables: [readme](https://docs.google.com/document/d/14A4sr626EKFpdObQkn3vfxBOPmSrKu9EnTKoaaLasW0/edit), [final report](https://docs.google.com/document/d/1-8nze2Vu-LiI_tgKZE_YyU98w75yo7zqRO_zT0_LsEc/edit), [project folder](https://drive.google.com/drive/folders/0B2MQdLyPsR4JM18yOXNWRjNaUGs)
+
+## Social Security Administration (SSA)
+
+### SSA / Disability Case Processing System (DCPS2) Path Analysis [#901](https://tock.18f.gov/projects/901/)
+- date: August 2018
+- Team: David Corwin, Eleni Gesch-Karamanlidis
+- Summary: SSA is seeking to identify the best technical solution for centralizing disability case processing. Determining how an internal disability case processing system (DCPS2) currently stacks up against commercially available alternatives, will help SSA determine whether to continue building or buy.
+- Deliverables: [final report](https://docs.google.com/document/d/1iqXwOsYDSC5BOvpHt_xVyqzIZK3QsNq6yskfJw45lCU/edit), [project folder](https://drive.google.com/drive/u/0/folders/1ln7PFz4hhzPbzQRnSbXcn7MS_mEenZQS?ogsrc=32)
+
+## Department of State (State)
+
+### State Operations Center Path Analysis [#798](https://tock.18f.gov/projects/798/)
+- June 2018
+- Team: Brandon Kirby, Kara Reinsel
+- Complete a current state analysis of elements of the Operations Center’s work and create a strategy and roadmap for how the State Department could move forward to modernize Operations Center processes and technology specifically related to knowledge management and information dissemination, and a high-level strategy for future state interoperability across all Operations Center systems.
+- Deliverables: [final report](https://docs.google.com/document/d/1oHZA5gBfY1l7skHCIkfvAyQK1MCbCH6wCCk7w4RmiH8/edit), [project folder](https://drive.google.com/drive/folders/1LkQE0mlQnXHXq3pvgn_k-CffFhd3X8DK)
+
+### State Department / Diamond Tracking Foundation Engagement [#748](https://tock.18f.gov/projects/748/)
+- March 2018
+- Team: Porta Antiporta, Vraj Mohan
+- Assess the problem space around the current website, database and data needs
+- Deliverables: [final report](https://docs.google.com/document/d/1svjmi0nURpRLyRr2O59fOo5zqVpIi4n4b5EdgAXhv-E/edit#heading=h.e8nss3dsefeh), [project folder](https://drive.google.com/drive/u/0/folders/1k5-ySsRUI0LynYif_bxfUvqJfuai4lMb)
+
+## Veterans Affairs (VA)
+
+### VA / Inquiry Routing and Information System (IRIS) Foundation Engagement [#527](https://tock.18f.gov/projects/527/)
+- May 2017
+- Team: Jeremy Canfield, Mark Trammell, Robert Sosinski
+- Take a comprehensive inventory of VA’s Inquiry Routing and Information System (IRIS) alongside the many other systems
+Veterans use and VA representatives work with. Build a roadmap for integrating IRIS and similar systems functionality into a more unified and effective veteran information support system.
+- Deliverables: [final report](https://drive.google.com/drive/u/0/folders/0B1bszTx6T0szUEdZNHlUNC1waDQ), [project folder](https://drive.google.com/drive/u/0/folders/0B8uvRFgNv6TAbGtJMFUya3Nma2s)
+
+## Independent agencies
+
+### National Science Foundation (NSF) / Site Redesign Foundation Engagement [#515](https://tock.18f.gov/projects/515/)
+- May 2017
+- Team: Brandon Kirby, Corey Mahoney 
+- NSF wanted help figuring out the future of NSF.gov: redesigning it to meet user needs, choosing and implementing a new content management system, and moving to the cloud. This foundation engagement aimed to help make this ambitious project successful by identifying risks, blockers, strengths, and opportunities, then recommending a roadmap for how NSF can approach this project to mitigate those risks.
+- Deliverables: [overview](https://docs.google.com/document/d/1cpD9buNqmrbgtXeM8uoYMC98A8Nf2WwXJD59SRIyAFs/edit#), [final report](https://docs.google.com/presentation/d/19pKR5a4aunJZd0lXWcK64h2dGZvcUZP7LlLfLY3A4iE/edit#slide=id.p), [project folder](https://drive.google.com/drive/u/0/folders/0B_FxR36sJSlCRE9vU1NrTzVQSm8) 
+
+### National Institutes of Health (NIH) National Library of Medicine (NLM) / Clinicaltrials.gov Discovery [#514](https://tock.18f.gov/projects/514/)
+- May 2017
+- Team: Angela Colter, Melissa Braxton, Austin Hernandez
+- Provide recommendations on how the National Library of Medicine’s ClinicalTrials.gov could better serve the needs of its users.
+- Deliverables: [final report](https://docs.google.com/document/d/10GxdXC3g9uOW3v8nCQYbs-sMgljhGxu1XQhVj9pL1us/edit), [project folder](https://drive.google.com/drive/u/0/folders/0B5gljoqLY5hqWFlWTmNRbk80Rm8), [project repo](https://github.com/18F/clinical-trials/wiki)
+
+### National Institutes of Health (NIH) / PubMed Foundation Engagement [#754](https://tock.18f.gov/projects/754/)
+- March 2018
+- Team: Victor Udoewa, Andrew Maier
+- Conduct user research in order to identify a potential roadmap for user-centered improvements to PubMed.gov and NLM literature offerings in general.
+- Deliverables: [readme](https://docs.google.com/document/d/1W2-SbeepLxEv9LfXjFelDg8u_6CxkMIY7wZZTDDh-wc/edit?ts=5a99b796), [final report](https://docs.google.com/presentation/d/1d7Rjme9tv5sQi9PMDPMv7Cmww4T-R3IuuUMmNm4iGfM/edit#slide=id.g35d13d9c9a_0_1349), [project folder](https://drive.google.com/drive/u/0/folders/1jPGVD44o3LoHlWI1KabzLBJe4SbhafNN)
+
+## General Services Administration (GSA)
+
+### OCIO / GAMS Foundation Engagement [#588](https://tock.18f.gov/projects/588/)
 - September 2017
 - Team: Nikki Zeichner, Amos Stone
 - Examine GAMS as a test bed for researching the current access management systems in place; research various modern authentication methods currently used in the commercial sector.
 - Deliverables: [final report](https://docs.google.com/document/d/1pP0LNUzoi_ZESMW2HRR-si0pzVn8kPDduIWI1wxUj1o/edit#heading=h.n9x70772ub7u), [project folder](https://drive.google.com/drive/u/0/folders/0B6M8a_9TXx6HcjZqdDVERk5xeFk)
 
-## Fish and Wildlife Service (FWS) / Harvest Surveys Foundation Engagement [#587](https://tock.18f.gov/projects/587/)
-- September 2017
-- Team: Alex Pandel, Ric Miller
-- The paper surveys of the annual activities of licensed migratory bird hunters are inefficient, tedious and often contain errors. FWS wants to automate this process to make it easier for their staff to collect information, enable hunters to report better data and decrease errors.
-- Deliverables: [readme](https://docs.google.com/document/d/195j01IFUkzQ34d3HAiD-VdnA1Fn_rrqR2VtUVLZ_4rM/edit), [final report](https://docs.google.com/document/d/1wfJn0Svbn189D4wmBquYt35alqi1awlNni0wHrhoZFk/edit#), [project folder](https://drive.google.com/drive/u/0/folders/0B66nw3kJR0r8TTJtSTVKcTRTNm8)
+### Federal Acquisition Service (FAS) / Commercial Platforms Foundation Engagement [#758](https://tock.18f.gov/projects/758/)
+- April 2018
+- Team: Michael Cata, Brandon Kirby
+- Define a high-level vision and roadmap for improving the federal purchasing experience.
+- Deliverables: [final report](https://docs.google.com/document/d/1ganft6g1jvChCiqCEABT4ZRX8523IvkDc6N4-YFKuN4/edit#heading=h.nfi7i0o0xz2c), [final presentation](https://docs.google.com/presentation/d/1VtPsmFP0f_FakW-ePs1PanlE0V-npSqMRE2zsjYUhoU/edit#slide=id.g35e4b9e59b_0_203), [project folder](https://drive.google.com/drive/u/0/folders/1St7ki-y6kEU9QvsbV75VgtRsstG0XXZU)
+
+### Federal Acquisition Service (FAS) / Integrated Awards Environment (IAE) Migration Foundation Engagement [#762](https://tock.18f.gov/projects/762/)
+- April 2018
+- Team: Porta Antiporta, Jon Carmack
+- Analyze the current state of IAE’s systems, review past documentation, and create a strategy and roadmap around how OSM should move forward with the migration of IAE’s system into a new environment.
+- Deliverables: [final report](https://docs.google.com/document/d/1QPmBna_RAyINxJGvmB8tWzCVX0mxBHQfEWEaA3hUxYA/edit), [final presentation](https://docs.google.com/presentation/d/1R8CuF6mGUoorgM25vOZQCUywjV9050DlTdvbwmVRtRA/edit#slide=id.p), [project folder](https://drive.google.com/drive/u/0/folders/1GkffL55wW4uTFXTB6Gf0W0MTV45Vy0j5)
 
 ## Federal Acquisition Service (FAS) / SWID Tag Repository Discovery [#562](https://tock.18f.gov/projects/562/)
 - September 2017
@@ -142,11 +185,29 @@ _Please note: many project deliverables are links to internal documents, and acc
 - Investigate the best way to build or acquire a repository for tracking government software licenses and their identification tags.
 - Deliverables: [final report](https://docs.google.com/document/d/12mefUAsK5PZ0BvKIqrY3hDhym6xeKrRqMd2dgxA7T90/edit#heading=h.3tid87unl71h), [presentation](https://docs.google.com/presentation/d/1llthw2my1PgOQNguwwQvSLiazabnF1yvbecpa5c6RH0/edit#slide=id.g1f6a537e68_0_455), [project folder](https://drive.google.com/drive/u/0/folders/0B6M8a_9TXx6HODNsckdDYkJRYWM)
 
-## Department of Homeland Security (DHS) / FEMA Foundation Engagement [#578](https://tock.18f.gov/projects/578/)
-- August 2017
-- Team: Michael Cata, Laura Ponce
-- Conduct user research and assess their workload forecasting challenges; make the Workforce Analysis Tool more user friendly.
-- Deliverables: [final report](https://docs.google.com/presentation/d/1mQOFi1P3MzTzIYOJ4iyBjNi-H0OWdi_AkbJs9qMxLXc/edit#slide=id.g24b041f5be_0_233), [project folder](https://drive.google.com/drive/u/0/folders/0B1iVxB_cv5hZR0FkMHRKY1QzVFk)
+### Federal Acquisition Service (FAS) ITC / Memo Compliance & Value Application Foundation Engagement [#517](https://tock.18f.gov/projects/517/)
+- April 2017
+- Team: Cyd Harrell, Michael Cata 
+- How can GSA help client agencies painlessly integrate IT guidance from OMB, and would this compliance guidance act as a compelling value-add service for GSA customers? While OMB guidance is confusing, this wasn't a burning user need. What they and their COs really wish is that GSA would make it easier to find vendors who can meet their specific requirements.
+- Deliverables: [final report](https://docs.google.com/document/d/1kigDq4JX_JVbAHaxaeDH-YtsgmbdRrvdB5fOtGeSfxk/edit), [project folder](https://drive.google.com/drive/u/0/folders/0B1iVxB_cv5hZTG9UNGVaTENEQVE)
+
+### Office of Products and Programs (OPP) / Social Security Number (SSN) Foundation Engagement [#493](https://tock.18f.gov/projects/493/)
+- January 2017
+- Team: Cyd Harrell, Ric Miller 
+- Assess the current environment of privacy-protecting citizen identifiers and demo the existing proof of concept of the Program Unique Identifier Initiative developed by OPM. Stopped the project after three weeks because there was no existing proof of concept and the partner wasn't ready to work with us.
+- Deliverables: [final report](https://docs.google.com/document/d/1Cts4OmwY8kEIMvgWF3bhR4hTBZgwczufptKEBz450D4/edit), [project folder](https://drive.google.com/drive/u/0/folders/0B15x0N-o0ueNTENxTlBPYllWcGc)
+
+### Office of Products and Programs / Performance.gov Foundation Engagement [#663](https://tock.18f.gov/projects/663/)
+- November 2017
+- Team: Victor Udoewa, Eddie Tejeda
+- Assess the archived Performance.gov and create a product vision and roadmap for a new, modernized Performance.gov
+- Deliverables: [readme](https://docs.google.com/document/d/18FBZ0yDos77KLRLOTVUU3hCA_oFczxJlHSIKgl3gwNY/edit?ts=5a99b58f), [final report](https://docs.google.com/presentation/d/1TFh3r3Cdd_wiCuli1rpY4RkkMXfYXIfXCS2fv7B5o7o/edit), [project folder](https://drive.google.com/drive/u/0/folders/0Bykd9KmMpACXRUl2RDdGZjNucFk)
+
+### Office of Products and Programs / Agency-wide Content Delivery Foundation Engagement [#647](https://tock.18f.gov/projects/647/)
+- October 2017
+- Team: Tim Jones, Andrew Maier
+- Assist OPP with market and user research, roadmap a vision for which roles TTS could effectively take on to help agencies with their content delivery needs.
+- Deliverables: [final report](https://docs.google.com/document/d/1v0IaGPTh981ZsBYOTCdo2CVy0IxJnzWO7-3HS2RMGDI/edit#), [project folder](https://drive.google.com/drive/u/0/folders/0B_SvrGV09nQ-V2NxSFhjUGs5LWs)
 
 ## Office of Products and Programs (OPP) / USA.gov Consolidated Permit System Foundation Engagement [#536](https://tock.18f.gov/projects/536/)
 - June 2017
@@ -154,39 +215,8 @@ _Please note: many project deliverables are links to internal documents, and acc
 - Learn more about the problem landscape as well as assess the viability of building a service to improve the user experience of land-use permit requests.
 - Deliverables: [final report](https://docs.google.com/presentation/d/1xwZmmCDvOKzzMEnaglql99NhwQEnp34vRNRIIUz0Lhc/edit#slide=id.g1f55217fec_0_372), [project folder](https://drive.google.com/drive/u/0/folders/0B_n2YScccqDXemRHOVZtcU9FdFU), [project repo](https://github.com/18F/FFD_landuse)
 
-## National Institutes of Health (NIH) National Library of Medicine (NLM) / Clinicaltrials.gov Discovery [#514](https://tock.18f.gov/projects/514/)
-- May 2017
-- Team: Angela Colter, Melissa Braxton, Austin Hernandez
-- Provide recommendations on how the National Library of Medicine’s ClinicalTrials.gov could better serve the needs of its users.
-- Deliverables: [final report](https://docs.google.com/document/d/10GxdXC3g9uOW3v8nCQYbs-sMgljhGxu1XQhVj9pL1us/edit), [project folder](https://drive.google.com/drive/u/0/folders/0B5gljoqLY5hqWFlWTmNRbk80Rm8), [project repo](https://github.com/18F/clinical-trials/wiki)
-
-## Veterans Affairs (VA) / Inquiry Routing and Information System (IRIS) Foundation Engagement [#527](https://tock.18f.gov/projects/527/)
-- May 2017
-- Team: Jeremy Canfield, Mark Trammell, Robert Sosinski
-- Take a comprehensive inventory of VA’s Inquiry Routing and Information System (IRIS) alongside the many other systems
-Veterans use and VA representatives work with. Build a roadmap for integrating IRIS and similar systems functionality into a more unified and effective veteran information support system.
-- Deliverables: [final report](https://drive.google.com/drive/u/0/folders/0B1bszTx6T0szUEdZNHlUNC1waDQ), [project folder](https://drive.google.com/drive/u/0/folders/0B8uvRFgNv6TAbGtJMFUya3Nma2s)
-
 ## Office of Products and Programs (OPP) / Small Business Grant Foundation Engagement [#528](https://tock.18f.gov/projects/528/)
 - May 2017
 - Team: Ric Miller, Carolyn Dew
 - After inheriting BusinessUSA, USAGov wanted to identify opportunities to improve how small businesses interact with the federal government. We set out to better understand how small businesses interact with the federal government, directly or indirectly. We focused on federal grant dollars that are awarded to state or local entities, and which are then issued as contracts with specific small or disadvantaged business requirements.
 - Deliverables: [final report](https://github.com/18F/OPP-BusinessUSA-research/blob/master/small-business-discovery-handout.md), [project repo](https://github.com/18F/OPP-BusinessUSA-research)
-
-## National Science Foundation / Site Redesign Foundation Engagement [#515](https://tock.18f.gov/projects/515/)
-- May 2017
-- Team: Brandon Kirby, Corey Mahoney 
-- NSF wanted help figuring out the future of NSF.gov: redesigning it to meet user needs, choosing and implementing a new content management system, and moving to the cloud. This foundation engagement aimed to help make this ambitious project successful by identifying risks, blockers, strengths, and opportunities, then recommending a roadmap for how NSF can approach this project to mitigate those risks.
-- Deliverables: [overview](https://docs.google.com/document/d/1cpD9buNqmrbgtXeM8uoYMC98A8Nf2WwXJD59SRIyAFs/edit#), [final report](https://docs.google.com/presentation/d/19pKR5a4aunJZd0lXWcK64h2dGZvcUZP7LlLfLY3A4iE/edit#slide=id.p), [project folder](https://drive.google.com/drive/u/0/folders/0B_FxR36sJSlCRE9vU1NrTzVQSm8) 
-
-## Federal Acquisition Service (FAS) ITC / Memo Compliance & Value Application Foundation Engagement [#517](https://tock.18f.gov/projects/517/)
-- April 2017
-- Team: Cyd Harrell, Michael Cata 
-- How can GSA help client agencies painlessly integrate IT guidance from OMB, and would this compliance guidance act as a compelling value-add service for GSA customers? While OMB guidance is confusing, this wasn't a burning user need. What they and their COs really wish is that GSA would make it easier to find vendors who can meet their specific requirements.
-- Deliverables: [final report](https://docs.google.com/document/d/1kigDq4JX_JVbAHaxaeDH-YtsgmbdRrvdB5fOtGeSfxk/edit), [project folder](https://drive.google.com/drive/u/0/folders/0B1iVxB_cv5hZTG9UNGVaTENEQVE)
-
-## Office of Products and Programs (OPP) / Social Security Number (SSN) Foundation Engagement [#493](https://tock.18f.gov/projects/493/)
-- January 2017
-- Team: Cyd Harrell, Ric Miller 
-- Assess the current environment of privacy-protecting citizen identifiers and demo the existing proof of concept of the Program Unique Identifier Initiative developed by OPM. Stopped the project after three weeks because there was no existing proof of concept and the partner wasn't ready to work with us.
-- Deliverables: [final report](https://docs.google.com/document/d/1Cts4OmwY8kEIMvgWF3bhR4hTBZgwczufptKEBz450D4/edit), [project folder](https://drive.google.com/drive/u/0/folders/0B15x0N-o0ueNTENxTlBPYllWcGc)

--- a/projects.md
+++ b/projects.md
@@ -10,13 +10,24 @@ _Please note: many project deliverables are links to internal documents, and acc
 - summary
 - Deliverables: [final report], [project folder]
 
+------
+
 ## Past projects
 
-- [Cabinet-level agencies](#Cabinet-level-agencies)
-  - [Agriculture (USDA)](#Department-of-Agriculture-USDA)
-  - [Commerce](#Department-of-Commerce-Commerce)
-- [Independent agencies]()
-- [General Services Administration]()
+- [Cabinet-level agencies](#cabinet-level-agencies)
+  + [Department of Agriculture](#department-of-agriculture-usda)
+  + [Department of Commerce](#department-of-commerce-commerce)
+  + [Department of Defense](#department-of-defense-dod)
+  + [Department of Homeland Security](#department-of-homeland-security-dhs)
+  + [Department of the Interior](#department-of-the-interior-doi)
+  + [Department of Justice](#department-of-justice-doj)
+  + [Department of State](#department-of-state-state)
+  + [Department of Veterans Affairs](#veterans-affairs-va)
+- [Independent agencies](#independent-agencies)
+  + [General Services Administration](#general-services-administration-gsa)
+  + [National Science Foundation](#national-science-foundation-nsf)
+  + [National Institutes of Health](#national-institutes-of-health-nih)
+  + [Social Security](#social-security-administration-ssa)
 
 ## Cabinet-level agencies
 
@@ -38,7 +49,7 @@ _Please note: many project deliverables are links to internal documents, and acc
 
 ### Department of Defense (DOD)
 
-### Department of Defense Education Activity (DoDEA) Cyber Training Ranges Foundation Engagement [#778](https://tock.18f.gov/projects/778/)
+#### Department of Defense Education Activity (DoDEA) Cyber Training Ranges Foundation Engagement [#778](https://tock.18f.gov/projects/778/)
 - May 2018
 - Team: David Kane-Perry, Eddie Tejeda
 - The Cyber Missions Forces have reported difficulty accessing training resources provided by cyber ranges. Timely access to cyber ranges and required training are crucial for ensuring that cyber teams are prepared to respond to increasing cyber threats.
@@ -109,14 +120,6 @@ _Please note: many project deliverables are links to internal documents, and acc
 - Team: Nikki Zeichner, Ed Mullen
 - Investigate creating the Data Ingest and Analytics Resource Center (DIARC) to integrate policies, processes, services, and technology into a shared service that is accessible to all litigation components.
 - Deliverables: [readme](https://docs.google.com/document/d/14A4sr626EKFpdObQkn3vfxBOPmSrKu9EnTKoaaLasW0/edit), [final report](https://docs.google.com/document/d/1-8nze2Vu-LiI_tgKZE_YyU98w75yo7zqRO_zT0_LsEc/edit), [project folder](https://drive.google.com/drive/folders/0B2MQdLyPsR4JM18yOXNWRjNaUGs)
-
-### Social Security Administration (SSA)
-
-#### SSA / Disability Case Processing System (DCPS2) Path Analysis [#901](https://tock.18f.gov/projects/901/)
-- date: August 2018
-- Team: David Corwin, Eleni Gesch-Karamanlidis
-- Summary: SSA is seeking to identify the best technical solution for centralizing disability case processing. Determining how an internal disability case processing system (DCPS2) currently stacks up against commercially available alternatives, will help SSA determine whether to continue building or buy.
-- Deliverables: [final report](https://docs.google.com/document/d/1iqXwOsYDSC5BOvpHt_xVyqzIZK3QsNq6yskfJw45lCU/edit), [project folder](https://drive.google.com/drive/u/0/folders/1ln7PFz4hhzPbzQRnSbXcn7MS_mEenZQS?ogsrc=32)
 
 ### Department of State (State)
 
@@ -205,20 +208,32 @@ Veterans use and VA representatives work with. Build a roadmap for integrating I
 - After inheriting BusinessUSA, USAGov wanted to identify opportunities to improve how small businesses interact with the federal government. We set out to better understand how small businesses interact with the federal government, directly or indirectly. We focused on federal grant dollars that are awarded to state or local entities, and which are then issued as contracts with specific small or disadvantaged business requirements.
 - Deliverables: [final report](https://github.com/18F/OPP-BusinessUSA-research/blob/master/small-business-discovery-handout.md), [project repo](https://github.com/18F/OPP-BusinessUSA-research)
 
-### National Science Foundation (NSF) / Site Redesign Foundation Engagement [#515](https://tock.18f.gov/projects/515/)
+### National Science Foundation (NSF)
+
+#### NSF Site Redesign Foundation Engagement [#515](https://tock.18f.gov/projects/515/)
 - May 2017
 - Team: Brandon Kirby, Corey Mahoney 
 - NSF wanted help figuring out the future of NSF.gov: redesigning it to meet user needs, choosing and implementing a new content management system, and moving to the cloud. This foundation engagement aimed to help make this ambitious project successful by identifying risks, blockers, strengths, and opportunities, then recommending a roadmap for how NSF can approach this project to mitigate those risks.
 - Deliverables: [overview](https://docs.google.com/document/d/1cpD9buNqmrbgtXeM8uoYMC98A8Nf2WwXJD59SRIyAFs/edit#), [final report](https://docs.google.com/presentation/d/19pKR5a4aunJZd0lXWcK64h2dGZvcUZP7LlLfLY3A4iE/edit#slide=id.p), [project folder](https://drive.google.com/drive/u/0/folders/0B_FxR36sJSlCRE9vU1NrTzVQSm8) 
 
-### National Institutes of Health (NIH) National Library of Medicine (NLM) / Clinicaltrials.gov Discovery [#514](https://tock.18f.gov/projects/514/)
+### National Institutes of Health (NIH)
+
+#### National Library of Medicine (NLM) / Clinicaltrials.gov Discovery [#514](https://tock.18f.gov/projects/514/)
 - May 2017
 - Team: Angela Colter, Melissa Braxton, Austin Hernandez
 - Provide recommendations on how the National Library of Medicine’s ClinicalTrials.gov could better serve the needs of its users.
 - Deliverables: [final report](https://docs.google.com/document/d/10GxdXC3g9uOW3v8nCQYbs-sMgljhGxu1XQhVj9pL1us/edit), [project folder](https://drive.google.com/drive/u/0/folders/0B5gljoqLY5hqWFlWTmNRbk80Rm8), [project repo](https://github.com/18F/clinical-trials/wiki)
 
-### National Institutes of Health (NIH) / PubMed Foundation Engagement [#754](https://tock.18f.gov/projects/754/)
+#### NIH / PubMed Foundation Engagement [#754](https://tock.18f.gov/projects/754/)
 - March 2018
 - Team: Victor Udoewa, Andrew Maier
 - Conduct user research in order to identify a potential roadmap for user-centered improvements to PubMed.gov and NLM literature offerings in general.
 - Deliverables: [readme](https://docs.google.com/document/d/1W2-SbeepLxEv9LfXjFelDg8u_6CxkMIY7wZZTDDh-wc/edit?ts=5a99b796), [final report](https://docs.google.com/presentation/d/1d7Rjme9tv5sQi9PMDPMv7Cmww4T-R3IuuUMmNm4iGfM/edit#slide=id.g35d13d9c9a_0_1349), [project folder](https://drive.google.com/drive/u/0/folders/1jPGVD44o3LoHlWI1KabzLBJe4SbhafNN)
+
+### Social Security Administration (SSA)
+
+#### SSA / Disability Case Processing System (DCPS2) Path Analysis [#901](https://tock.18f.gov/projects/901/)
+- date: August 2018
+- Team: David Corwin, Eleni Gesch-Karamanlidis
+- Summary: SSA is seeking to identify the best technical solution for centralizing disability case processing. Determining how an internal disability case processing system (DCPS2) currently stacks up against commercially available alternatives, will help SSA determine whether to continue building or buy.
+- Deliverables: [final report](https://docs.google.com/document/d/1iqXwOsYDSC5BOvpHt_xVyqzIZK3QsNq6yskfJw45lCU/edit), [project folder](https://drive.google.com/drive/u/0/folders/1ln7PFz4hhzPbzQRnSbXcn7MS_mEenZQS?ogsrc=32)


### PR DESCRIPTION
This PR reorganizes the `projects.md` file to make it easier to use — namely, to organize it by agency, so that new PA teams can focus on prior similar projects. Within each agency, the projects are in reverse-chron order. This also adds a table of contents.

Fixes #15 